### PR TITLE
Close kafkaProducer when !useCachedProducer

### DIFF
--- a/src/javasource/kafka/actions/SendAsynchronous.java
+++ b/src/javasource/kafka/actions/SendAsynchronous.java
@@ -78,6 +78,11 @@ public class SendAsynchronous extends CustomJavaAction<java.lang.Boolean>
 		}
 		
 		kafkaProducer.send(record);
+
+		if (!useCachedProducer) {
+			// If not useCachedProducer Prevent keeping the kafkaProducer instance in memory and retry every x/min to Kafka
+			kafkaProducer.close();
+		}
 		
 		return true;
 		// END USER CODE

--- a/src/javasource/kafka/actions/SendSynchronous.java
+++ b/src/javasource/kafka/actions/SendSynchronous.java
@@ -87,6 +87,12 @@ public class SendSynchronous extends CustomJavaAction<IMendixObject>
 		Future<RecordMetadata> future = kafkaProducer.send(producerRecord);
 		RecordMetadata record = future.get();
 		RecordMetaData result = new RecordMetaData(getContext());
+
+		if (!useCachedProducer) {
+			// If not useCachedProducer Prevent keeping the kafkaProducer instance in memory and retry every x/min to Kafka
+			kafkaProducer.close();
+		}
+
 		result.setHasOffset(record.hasOffset());
 		if (record.hasOffset())
 			result.setOffset(record.offset());


### PR DESCRIPTION
This PR is to fix a serious issue that causes this extension when my customer Dev Team weren't using the useCacheProducer.
This causes their Mendix Application to create a new KafkaProducer instance each time the application was producing a new message to Kafka. 
This leads us to have more than 500 KafkaProducer running in memory as  a kind of zombie instance reaching our Kafka Cluster each min (thanks to the retry mecanims). 
We notice more than 500,000 Kafka.Authentication events from Confluent.Cloud AuditLogs only after two days of the first application start. This number was increasing each day more and more. Restart the application each day was not a valid option.

My customer Dev Team manages to simply use the "useCachedProducer" parameter in order to use it properly, but I really want to fix this code to avoid anyone having back that issue.